### PR TITLE
fix(fastqcParse): fastqcParser now accounts for missing modules

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -7,8 +7,8 @@ db:
     password: password
 files:
   - name: fastqc
-    directory: /Users/aguang/CORE/qckit/qcdb/tests/data/
+    directory: /Users/aguang/CORE/qcdb/qcdb/tests/data/
   - name: qckitfastq
-    directory: /Users/aguang/CORE/qckit/qcdb/tests/data/
+    directory: /Users/aguang/CORE/qcdb/qcdb/tests/data/
   - name: picardtools
-    directory: /Users/aguang/CORE/qckit/qcdb/tests/data/
+    directory: /Users/aguang/CORE/qcdb/qcdb/tests/data/

--- a/qcdb/db_load.py
+++ b/qcdb/db_load.py
@@ -50,8 +50,8 @@ def insert(results, m, session):
         session.execute(metrics.insert(), results.metrics)
         session.commit()
     except:
-        raise Exception('Data already exists')
-        log.error("Data already exists for {}...".format(results.db_id))
+        log.error('Data already exists for {}'.format(results.db_id))
+        raise Exception("Data already exists")
 
 def dispatch_parse(directory, module_name, module_glob, module_fn, session, m, refs, build_ref):
     files = glob2.glob(os.path.join(directory, module_glob))
@@ -65,7 +65,9 @@ def dispatch_parse(directory, module_name, module_glob, module_fn, session, m, r
         try:
             insert(results, m, session)
         except:
-            log.error("Error in insert for {}...".format(f))
+            pass
+            #seems like uninformative error message
+            #log.error("Error in insert for {}...".format(f))
 
 # parse and load metadata
 def parse(d, m, session, build_ref):

--- a/qcdb/parsers/fastqc_parse.py
+++ b/qcdb/parsers/fastqc_parse.py
@@ -22,15 +22,10 @@ class fastqcParser(BaseParser):
         log.info("Initializing fastqcParser for {}...".format(file_handle))
         BaseParser.__init__(self,file_handle,'fastqc', session, ref_table, build_ref)
 
-        metrics = ['basequal', 'tilequal', 'seqqual', 'perbaseseqcontent',
-            'gccontent', 'perbaseNcontent', 'seqlength', 'seqdup', 'overseqs',
-            'adaptcontent', 'kmercount']
-
-        self.parse(file_handle, metrics)
+        self.parse(file_handle)
 
     # data parse
-    # largely taken from: https://github.com/compbiocore/bioflows/blob/master/bioflows/bioutils/parse_fastqc/parsefastqc.py
-    def parse(self, file, metrics):
+    def parse(self, file):
         '''
         read in the results in zipfile and return parsed file
         :return: list of output and tuple with location of modules
@@ -39,32 +34,30 @@ class fastqcParser(BaseParser):
         results_idx = next((i for i, item in enumerate(zp.namelist()) if re.search('fastqc_data.txt',item)), None)
         lines = zp.open(zp.namelist()[results_idx]).readlines()
 
-        # Generate a tuple for the start and end locs of the modules 12 in total
-            # ['>>Basic Statistics\tpass\n',
-            #  '>>Per base sequence quality\tpass\n',
-            #  '>>Per tile sequence quality\twarn\n',
-            #  '>>Per sequence quality scores\tpass\n',
-            #  '>>Per base sequence content\twarn\n',
-            #  '>>Per sequence GC content\tpass\n',
-            #  '>>Per base N content\tpass\n',
-            #  '>>Sequence Length Distribution\tpass\n',
-            #  '>>Sequence Duplication Levels\tfail\n',
-            #  '>>Overrepresented sequences\twarn\n',
-            #  '>>Adapter Content\tpass\n',
-            #  '>>Kmer Content\tfail\n']
-
-        module_start_idx = [i for i, item in enumerate(lines) if re.search(r"(^#(?!(Total\sDeduplicated\sPercentage\s).*))", item.decode('utf-8'))]
-        #del(module_start_idx[9]) # sequence duplication levels has two comment lines so we only want the last one, now achieved through a regex rather than accessing elements of the list
         module_end_idx = [i for i, item in enumerate(lines) if re.search('^>>END_MODULE', item.decode('utf-8'))]
+        module_start_idx = [i+1 for i in module_end_idx]
+        metrics = modules(module_start_idx[:-1],lines)
 
-        for start, end, module in zip(module_start_idx[2:], module_end_idx[1:], metrics):
-            # pre-mapped column names
+        for start, end, module in zip(module_start_idx[:-1], module_end_idx[1:], metrics):
+            start = start+1 # column names are line after start
+
+            # some edge cases
+            if module=='seqdup': # sequence duplicaiton levels come with two comment lines
+                start = start+1 # so we just keep the last one for column names
+
+            if start==end: # if module is empty, like overrep sequences
+                continue
+
             columns = lines[start].decode('utf-8').lstrip('#').strip('\n').split('\t')
 
             if self.build_ref and module not in self.ref_map:
                 metric_map = {}
             else:
-                metric_map = self.ref_map[module]
+                try:
+                    metric_map = self.ref_map[module]
+                except:
+                    log.error("No reference map (maybe you need to run with --buildref flag)")
+                    raise Exception('No reference map')
 
             new_cols = []
             for column in columns:
@@ -79,9 +72,51 @@ class fastqcParser(BaseParser):
                     raise Exception('Metric type does not have a mapped code')
 
             rows = lines[start+1:end-1]
-
             # if no data right now JSON will be empty. OK solution?
 
             # now want dictionary of db_id, qc_program (fastqc), qc_metric (each metric), json
             self.metrics.append({'db_id': self.db_id, 'qc_program': 'fastqc', 'qc_metric': module,
                 'data': json_dump(new_cols, rows)})
+
+def modules(start, lines):
+    # Generate a tuple for the start and end locs of the modules 12 in total
+    # ['>>Basic Statistics\tpass\n',
+    #  '>>Per base sequence quality\tpass\n',
+    #  '>>Per tile sequence quality\twarn\n',
+    #  '>>Per sequence quality scores\tpass\n',
+    #  '>>Per base sequence content\twarn\n',
+    #  '>>Per sequence GC content\tpass\n',
+    #  '>>Per base N content\tpass\n',
+    #  '>>Sequence Length Distribution\tpass\n',
+    #  '>>Sequence Duplication Levels\tfail\n',
+    #  '>>Overrepresented sequences\twarn\n',
+    #  '>>Adapter Content\tpass\n',
+    #  '>>Kmer Content\tfail\n']
+    modules = []
+    for i in start:
+        if lines[i].decode('utf-8').startswith(">>Per base sequence quality"):
+            modules.append('basequal')
+        elif lines[i].decode('utf-8').startswith(">>Per tile"):
+            modules.append('tilequal')
+        elif lines[i].decode('utf-8').startswith(">>Per sequence quality scores"):
+            modules.append('seqqual')
+        elif lines[i].decode('utf-8').startswith(">>Per base sequence content"):
+            modules.append('perbaseseqcontent')
+        elif lines[i].decode('utf-8').startswith(">>Per sequence GC content"):
+            modules.append('gccontent')
+        elif lines[i].decode('utf-8').startswith(">>Per base N content"):
+            modules.append('perbaseNcontent')
+        elif lines[i].decode('utf-8').startswith(">>Sequence Length Distribution"):
+            modules.append('seqlength')
+        elif lines[i].decode('utf-8').startswith(">>Sequence Duplication"):
+            modules.append('seqdup')
+        elif lines[i].decode('utf-8').startswith(">>Overrepresented sequences"):
+            modules.append('overseqs')
+        elif lines[i].decode('utf-8').startswith(">>Adapter"):
+            modules.append('adaptcontent')
+        elif lines[i].decode('utf-8').startswith(">>Kmer Content"):
+            modules.append('kmercount')
+        else:
+            raise Exception("No modules known to be fastqc found")
+            log.error("No modules known to be fastqc found")
+    return modules

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+from sqlalchemy import *
+from sqlalchemy.orm import Session
+import pytest
+import os
+from qcdb.db_create import tables, db_create
+from qcdb.connection import connection
+import oyaml as yaml
+
+@pytest.fixture
+def test_yaml():
+	dirname = os.path.dirname(__file__)
+	with open(os.path.join(dirname, 'test_params.yaml'), 'r') as io:
+		d = yaml.load(io, Loader=yaml.FullLoader)
+		return(d)
+
+@pytest.fixture
+def test_data():
+	dirname = os.path.dirname(__file__)
+	return(os.path.join(dirname,'data'))
+
+@pytest.fixture(scope='session')
+def con(request):
+    params = {'user': 'root',
+              'password': 'password',
+              'host': os.getenv("MYSQL_HOST"),
+              'port': 3306,
+              'raise_on_warnings': True
+              }
+
+    try:
+        con = connection(params,db="test")
+    except:
+        db_create(params,db="test")
+        con = connection(params,db="test")
+
+    metadata = tables(MetaData())
+    metadata.create_all(con, checkfirst=True)
+
+    # need to work on this as right now the db doesn't get
+    # deleted
+    def teardown():
+         con = connection(params,db="test")
+         con.execute("drop database test;")
+         con.close()
+
+    request.addfinalizer(teardown)
+    return con
+
+@pytest.fixture(scope='session')
+def metadata(con):
+	m = MetaData()
+	m.reflect(bind=con)
+	return(m)
+
+@pytest.fixture(scope='session')
+def session(con, request):
+	transaction = con.begin()
+	session = Session(bind=con)
+
+	def teardown():
+		session.close()
+		transaction.rollback()
+		con.close()
+
+	request.addfinalizer(teardown)
+	return session

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,135 +1,13 @@
-from sqlalchemy import *
-from sqlalchemy.orm import Session
-import oyaml as yaml
 import pytest
 import os
-from qcdb.db_create import tables, db_create
-from qcdb.connection import connection
 
 from dotenv import load_dotenv
 load_dotenv()
-
-@pytest.fixture
-def test_yaml():
-	dirname = os.path.dirname(__file__)
-	with open(os.path.join(dirname, 'test_params.yaml'), 'r') as io:
-		d = yaml.load(io, Loader=yaml.FullLoader)
-		return(d)
-
-@pytest.fixture
-def test_data():
-	dirname = os.path.dirname(__file__)
-	return(os.path.join(dirname,'data'))
-
-@pytest.fixture(scope='session')
-def con(request):
-    params = {'user': 'root',
-              'password': 'password',
-              'host': os.getenv("MYSQL_HOST"),
-              'port': 3306,
-              'raise_on_warnings': True
-              }
-
-    try:
-        con = connection(params,db="test")
-    except:
-        db_create(params,db="test")
-        con = connection(params,db="test")
-
-    metadata = tables(MetaData())
-    metadata.create_all(con, checkfirst=True)
-
-    # need to work on this as right now the db doesn't get
-    # deleted
-    def teardown():
-         con = connection(params,db="test")
-         con.execute("drop database test;")
-         con.close()
-
-    request.addfinalizer(teardown)
-    return con
-
-@pytest.fixture(scope='session')
-def metadata(con):
-	m = MetaData()
-	m.reflect(bind=con)
-	return(m)
-
 
 # Tests that there are only 3 tables
 def test_3_tables(metadata):
 	tables = metadata.tables.keys()
 	assert(len(tables)==3)
-
-@pytest.fixture(scope='session')
-def session(con, request):
-	transaction = con.begin()
-	session = Session(bind=con)
-
-	def teardown():
-		session.close()
-		transaction.rollback()
-		con.close()
-
-	request.addfinalizer(teardown)
-	return session
-
-# # TEST PARSERS
-
-import glob2
-import os
-import pytest
-from qcdb.parsers.parse import BaseParser
-from qcdb.parsers.fastqc_parse import fastqcParser
-from qcdb.parsers.qckitfastq_parse import qckitfastqParser
-from qcdb.parsers.picardtools_parse import picardtoolsParser
-
-dirname = os.path.dirname(__file__)
-
-def test_library_read_type(session, metadata):
-	assert(BaseParser("SRS1_SRX2_1","a", session, metadata.tables['reference'], true).library_read_type=='paired-end forward')
-	assert(BaseParser("SRS1_SRX2_2",'b', session, metadata.tables['reference'], true).library_read_type=='paired-end reverse')
-	assert(BaseParser("SRS1_SRX2_a",'c', session, metadata.tables['reference'], true).library_read_type=='single ended')
-	with pytest.raises(KeyError):
-		BaseParser("SRS1_SRX2_3",'d', session, metadata.tables['reference'], true)
-
-def test_fastqcparser(session, metadata):
-	results = []
-	files = glob2.glob(os.path.join(dirname, 'data', '*_fastqc.zip'))
-	for f in files:
-		results.append(fastqcParser(f, session, metadata.tables['reference'], true))
-	for r in results:
-		assert(isinstance(r, fastqcParser))
-		assert(r.sample_id.startswith('SRS'))
-		assert(r.experiment.startswith('SRX'))
-		# don't have paired end test files right now
-		assert(r.db_id.split('_')[2]=='se')
-		assert(r.library_read_type=='single ended')
-		# FASTQC has 11 modules
-		# could do this based off of the tables YAML as an auto check
-		assert(len(r.metrics) == 11)
-
-	# test that the reference table updated with minified values
-	count = 0
-	for row in session.execute(metadata.tables['reference'].select()):
-		if count == 0:
-			assert(len(row['field_name']) > len(row['field_code']))
-		count +=1
-	assert(count > 0)
-
-def test_qckitfastqparser(session, metadata):
-	results = qckitfastqParser(os.path.join(dirname, 'data', 'SRS643403_SRX612437_overrep_kmer.csv'), session, metadata.tables['reference'], true)
-	assert(results.sample_id.startswith('SRS'))
-	assert(results.experiment.startswith('SRX'))
-	assert(results.db_id.split('_')[2]=='se')
-	assert(results.library_read_type=='single ended')
-	assert(len(results.metrics)==1)
-
-def test_picardtoolsparser(session, metadata):
-    results = picardtoolsParser(os.path.join(dirname, 'data', 'SRS999999_SRX999999_summary_gcbias_metrics_picard.txt'), session, metadata.tables['reference'], true)
-    assert(results.sample_id.startswith('SRS'))
-    assert(results.experiment.startswith('SRX'))
-    assert(len(results.metrics) == 1)
 
 # # TEST DB_LOAD
 
@@ -140,9 +18,11 @@ def test_parse_nobuildref(metadata,session,test_yaml):
 		session.execute("DELETE from references;")
 		dbl.parse(test_yaml,metadata,session,False)
 
+from qcdb.parsers.fastqc_parse import fastqcParser
+dirname = os.path.dirname(__file__)
 
 def test_insert(metadata,session):
-	results = fastqcParser(os.path.join(dirname,'data','SRS643404_SRX612438_fastqc.zip'), session, metadata.tables['reference'], False)
+	results = fastqcParser(os.path.join(dirname,'data','SRS643404_SRX612438_fastqc.zip'), session, metadata.tables['reference'], True)
 	dbl.insert(results,metadata,session)
 	s = metadata.tables['samplemeta']
 	print(s.c.db_id)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,63 @@
+# # TEST PARSERS
+import glob2
+import os
+import pytest
+from qcdb.parsers.parse import BaseParser
+from qcdb.parsers.fastqc_parse import fastqcParser
+from qcdb.parsers.qckitfastq_parse import qckitfastqParser
+from qcdb.parsers.picardtools_parse import picardtoolsParser
+
+dirname = os.path.dirname(__file__)
+
+def test_library_read_type(session, metadata):
+	assert(BaseParser("SRS1_SRX2_1","a", session, metadata.tables['reference'], True).library_read_type=='paired-end forward')
+	assert(BaseParser("SRS1_SRX2_2",'b', session, metadata.tables['reference'], True).library_read_type=='paired-end reverse')
+	assert(BaseParser("SRS1_SRX2_a",'c', session, metadata.tables['reference'], True).library_read_type=='single ended')
+	with pytest.raises(KeyError):
+		BaseParser("SRS1_SRX2_3",'d', session, metadata.tables['reference'], True)
+
+def test_fastqcparser(session, metadata):
+	r = fastqcParser(os.path.join(dirname, 'data', 'SRS643403_SRX612437_fastqc.zip'), session, metadata.tables['reference'], True)
+	assert(isinstance(r, fastqcParser))
+	assert(r.sample_id.startswith('SRS'))
+	assert(r.experiment.startswith('SRX'))
+	assert(r.library_read_type=='single ended')
+	assert(len(r.metrics)==11)
+
+	# test that the reference table updated with minified values
+	count = 0
+	for row in session.execute(metadata.tables['reference'].select()):
+		if count == 0:
+			assert(len(row['field_name']) > len(row['field_code']))
+		count +=1
+	assert(count > 0)
+
+def test_fastqcparser_notilequal(session, metadata):
+	r = fastqcParser(os.path.join(dirname, 'data', 'SRS4807080_SRX5884550_1_fastqc.zip'), session, metadata.tables['reference'], True)
+	assert(isinstance(r, fastqcParser))
+	assert(r.sample_id.startswith('SRS'))
+	assert(r.experiment.startswith('SRX'))
+	assert(r.library_read_type=='paired-end forward')
+	assert(len(r.metrics)==10)
+
+def test_fastqcparser_notile_nooverrep(session, metadata):
+	r = fastqcParser(os.path.join(dirname, 'data', 'SRS4807083_SRX5884553_2_fastqc.zip'), session, metadata.tables['reference'], True)
+	assert(isinstance(r, fastqcParser))
+	assert(r.sample_id.startswith('SRS'))
+	assert(r.experiment.startswith('SRX'))
+	assert(r.library_read_type=='paired-end reverse')
+	assert(len(r.metrics)==9)	
+
+def test_qckitfastqparser(session, metadata):
+	results = qckitfastqParser(os.path.join(dirname, 'data', 'SRS643403_SRX612437_overrep_kmer.csv'), session, metadata.tables['reference'], True)
+	assert(results.sample_id.startswith('SRS'))
+	assert(results.experiment.startswith('SRX'))
+	assert(results.db_id.split('_')[2]=='se')
+	assert(results.library_read_type=='single ended')
+	assert(len(results.metrics)==1)
+
+def test_picardtoolsparser(session, metadata):
+    results = picardtoolsParser(os.path.join(dirname, 'data', 'SRS999999_SRX999999_summary_gcbias_metrics_picard.txt'), session, metadata.tables['reference'], True)
+    assert(results.sample_id.startswith('SRS'))
+    assert(results.experiment.startswith('SRX'))
+    assert(len(results.metrics) == 1)


### PR DESCRIPTION
fastqcParser used to assume you would have data for all 11 modules, however this is not the case for some samples as they may be missing tile quality because they are not Illumina data, or they may not have overrepresented sequences. In that case the indexing for modules became erroneous, which triggered issues with column names and data insertion. It is now fixed so that it only parses for modules which it finds in the `fastqc_data.txt` file.

close #28